### PR TITLE
Historical data mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 
 WeatherInjection.log
+*.csv

--- a/AWCWeatherInjection.ps1
+++ b/AWCWeatherInjection.ps1
@@ -123,6 +123,9 @@ Try {
 			$todayDay = (Get-Date).ToUniversalTime().ToString("dd")
 			if($InjectionSettings.Settings.Time.Day) {
 				$todayDay = $InjectionSettings.Settings.Time.Day
+				if($todayDay.Length -eq 1) {
+					$todayDay = "0$todayDay"
+				}
 			}
 			$todayTime = (Get-Date).ToUniversalTime().ToString("HH:mm")
 			if($InjectionSettings.Settings.Time.Time) {
@@ -253,7 +256,7 @@ Try {
 			if(-not ($historicdata[$i].elevation -eq "M")) {
 				$weatherxml.response.data.metar.elevation_m = "$([int]$historicdata[$i].elevation)"
 			}
-			#$weatherxml.Save("test.xml") #For debugging the fake XML
+			$weatherxml.Save("test.xml") #For debugging the fake XML
 		}
         $debugMETAR = $weatherxml.response.data.metar.raw_text
         Write-Log "INFO" "TDS METAR: $debugMETAR" $Log

--- a/AWCWeatherInjection.ps1
+++ b/AWCWeatherInjection.ps1
@@ -2,7 +2,7 @@
     Author: Mr_Superjaffa#5430
     Description: Inject real world weather into DCS .miz file for use on servers.
     Version: v0.7.2
-    Modified: Dec 25/2021
+    Modified: Jan 07/2022
     Notes: N/A
 #>
 

--- a/AWCWeatherInjection.ps1
+++ b/AWCWeatherInjection.ps1
@@ -2,7 +2,7 @@
     Author: Mr_Superjaffa#5430
     Description: Inject real world weather into DCS .miz file for use on servers.
     Version: v0.7.2
-    Modified: May 15/2021
+    Modified: Dec 25/2021
     Notes: N/A
 #>
 

--- a/AWCWeatherInjection.ps1
+++ b/AWCWeatherInjection.ps1
@@ -437,6 +437,7 @@ If ($InjectionSettings.Settings.Weather.CloudBase_FtMSL) {
 } Else {
     $cloudBaseMSL = $null
 }
+Write-Log "INFO" "Cloud Base: $cloudBaseMSL ft MSL" $Log
 
 # Checking cloud base against user constraints
 If ($InjectionSettings.Settings.Constraints.MinCloudBase_FtMSL -and ($cloudBaseMSL -lt $InjectionSettings.Settings.Constraints.MinCloudBase_FtMSL)) {
@@ -744,29 +745,29 @@ If ($mission[(GetMissionElement("qnh"))] -match "qnh" -and $Pressure) {
 
 # Exporting cloud height
 Try {
-If ($mission[(GetMissionElement("clouds")) + 2] -match "thickness" -and $cloudHeight) {
-    $mission[(GetMissionElement("clouds")) + 2] = "`t`t`t[`"thickness`"] = $cloudHeight,"
+If ($mission[(GetMissionElement("clouds")) + 3] -match "thickness" -and $cloudHeight) {
+    $mission[(GetMissionElement("clouds")) + 3] = "`t`t`t[`"thickness`"] = $cloudHeight,"
     Write-Log "INFO" "Exported cloud height." $Log
 }} Catch {Write-Log "ERROR" "Cloud height export failed!" $Log}
 
 # Exporting cloud coverage
 Try {
-If ($mission[(GetMissionElement("clouds")) + 3] -match "density" -and ($cloudCoverage -gt -1)) {
-    $mission[(GetMissionElement("clouds")) + 3] = "`t`t`t[`"density`"] = $cloudCoverage,"
+If ($mission[(GetMissionElement("`"density`""))] -match "density" -and ($cloudCoverage -gt -1)) {
+    $mission[(GetMissionElement("`"density`""))] = "`t`t`t[`"density`"] = $cloudCoverage,"
     Write-Log "INFO" "Exported cloud coverage." $Log
 }} Catch {Write-Log "ERROR" "Cloud coverage export failed!" $Log}
 
 # Exporting cloud base
 Try {
-If ($mission[(GetMissionElement("clouds")) + 4] -match "base" -and $cloudBaseMSL) {
-    $mission[(GetMissionElement("clouds")) + 4] = "`t`t`t[`"base`"] = $cloudBaseMSL,"
+If ($mission[(GetMissionElement("`"base`""))] -match "base" -and $cloudBaseMSL) {
+    $mission[(GetMissionElement("`"base`""))] = "`t`t`t[`"base`"] = $cloudBaseMSL,"
     Write-Log "INFO" "Exported cloud base." $Log
 }} Catch {Write-Log "ERROR" "Cloud base export failed!" $Log}
 
 # Exporting precipitation
 Try {
-If ($mission[(GetMissionElement("clouds")) + 5] -match "iprecptns" -and $Precipitation -ge 0) {
-    $mission[(GetMissionElement("clouds")) + 5] = "`t`t`t[`"iprecptns`"] = $Precipitation,"
+If ($mission[(GetMissionElement("`"iprecptns`""))] -match "iprecptns" -and $Precipitation -ge 0) {
+    $mission[(GetMissionElement("`"iprecptns`""))] = "`t`t`t[`"iprecptns`"] = $Precipitation,"
     Write-Log "INFO" "Exported precipitation." $Log
 }} Catch {Write-Log "ERROR" "Precipitation export failed!"}
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 
 # AWCWeatherInjection for Windows & DCS World
-Version 0.6.7 by Mr_Superjaffa#5430
+Version 0.7.2 by Mr_Superjaffa#5430
 
 The goal of this project is to provide weather and time injection to DCS World missions using Aviation Weather Centre's Text Data Service.
 

--- a/WeatherInjectionSettings.xml
+++ b/WeatherInjectionSettings.xml
@@ -7,9 +7,9 @@
 		<Mission></Mission> <!-- THIS WILL OVERRIDE THE SERVER CONFIG -->
 	</Setup>
 	<General>
-		<AirportICAO>URSS</AirportICAO>
+		<AirportICAO>KLSV</AirportICAO>
 		<EnableTime>False</EnableTime>
-		<TimeFormat>Random</TimeFormat> <!-- "Zulu", "Local", "Random" -->
+		<TimeFormat>Zulu</TimeFormat> <!-- "Zulu" or "Local" -->
 		<DEBUG>False</DEBUG>
 	</General>
 	<Weather>
@@ -23,7 +23,7 @@
 		<Wind2000Dir></Wind2000Dir>
 		<Wind8000SpeedKts></Wind8000SpeedKts>
 		<Wind8000Dir></Wind8000Dir>
-		<Turbulence></Turbulence> <!-- -->
+		<Turbulence></Turbulence> <!-- m/s -->
 		<!-- Clouds and Precipitation -->
 		<CloudBase_FtMSL></CloudBase_FtMSL> <!-- -->
 		<CloudHeight_Ft></CloudHeight_Ft> <!-- -->

--- a/WeatherInjectionSettings.xml
+++ b/WeatherInjectionSettings.xml
@@ -9,7 +9,7 @@
 	<General>
 		<AirportICAO>KLSV</AirportICAO>
 		<EnableTime>False</EnableTime>
-		<TimeFormat>Zulu</TimeFormat> <!-- "Zulu" or "Local" -->
+		<TimeFormat>Zulu</TimeFormat> <!-- "Zulu", "Local", "Random" -->
 		<DEBUG>False</DEBUG>
 	</General>
 	<Weather>


### PR DESCRIPTION
Allows for use of historical data from a file if a requested airport no longer reports its METARs via AWC. Historical mode attempts to match the requested month & date in the provided historical data, then tries to find a METAR as close as possible to the requested time as possible.

Also:
* Fix proper export of clouds properties base; thickness; density
* Write cloud base in log file